### PR TITLE
Fixing validateResponseSummaries for the runFetchAnswerQuery in fetchAnswer

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -70,7 +70,7 @@ const schema = Joi.object({
 const config = {
   env: process.env.NODE_ENV,
   appInsightsKey: process.env.APPINSIGHTS_CONNECTIONSTRING,
-  version: '0.1.40',
+  version: '0.1.41',
   logLevel: process.env.LOG_LEVEL || 'error',
 
   auth: {

--- a/app/domain/prompt.js
+++ b/app/domain/prompt.js
@@ -8,7 +8,7 @@ const getPrompt = (summariesMode) => {
   Documents will be provided to you with two constituent parts; an identifier and the content. The identifier will be at the start of the document, within a set of parentheses in the following format:
     (Title: Document Title | Grant Scheme Name: Grant Scheme the grant option belongs to | Source: Document Source URL | Chunk Number: The chunk number for a given parent document)
     The start of the content will follow the "===" string in the document.
-    ${summariesMode && 'The documents provided may not include the relevant information to answer the query sufficiently. If you do not find the relevant grants, or they do not exist in the provided documents, always respond only with "Unknown" as the answer.'}
+    ${summariesMode && 'The documents provided may not include the relevant information to answer the query sufficiently. If the document do not mention or include the information,always respond only with "Unknown" as the answer.'}
     
   - Respond in British English, not American English.
   - Use a neutral tone without being too polite. 

--- a/app/services/query-service.js
+++ b/app/services/query-service.js
@@ -32,22 +32,6 @@ const validateResponseLinks = (response, query) => {
       return trackIssueAndBreak('validateResponseLinks failed because response object does not contain answer or context fields')
     }
 
-    // while it still does not return JSON always, have this check to avoid invalidating reasonable string responses
-    if (typeof response.answer === 'string'
-      && !response.answer.includes('Unknown')
-      && !response.answer.includes('tool cannot answer that kind of question')
-      && response.answer.length > 100
-      && !response.answer.includes('not mentioned in the provided documents')
-      && !response.answer.includes('not included in the provided documents')
-      && !response.answer.includes('not found in the provided documents')
-      && !response.answer.includes('documents do not mention')
-      && !response.answer.includes('documents do not include')
-      && !response.answer.includes('not found in the documents')
-      && !response.answer.includes('not mentioned in the documents')
-    ) {
-      return true
-    }
-
     const responseEntriesAndLinks = extractLinksForValidatingResponse(JSON.parse(response.answer))
     const trueEntriesAndLinks = extractLinksForValidatingResponse(response.context)
 
@@ -55,7 +39,11 @@ const validateResponseLinks = (response, query) => {
       return trackIssueAndBreak('validateResponseLinks failed because no links detected in true context object')
     }
 
-    if (!responseEntriesAndLinks && !trueEntriesAndLinks || (responseEntriesAndLinks !== undefined && responseEntriesAndLinks.length !== 0 && trueEntriesAndLinks !== undefined && trueEntriesAndLinks.length === 0)) {
+    if (!responseEntriesAndLinks && !trueEntriesAndLinks) {
+      return trackIssueAndBreak('validateResponseLinks failed because hallucinated links detected in response objects')
+    }
+
+    if (responseEntriesAndLinks !== undefined && responseEntriesAndLinks.length !== 0 && trueEntriesAndLinks !== undefined && trueEntriesAndLinks.length === 0) {
       return trackIssueAndBreak('validateResponseLinks failed because hallucinated links detected in response objects')
     }
 

--- a/app/services/query-service.js
+++ b/app/services/query-service.js
@@ -130,7 +130,7 @@ const runFetchAnswerQuery = async ({ query, chatHistory, summariesMode, embeddin
   }
 }
 
-const fetchAnswer = async (req, query, chatHistory) => {
+const fetchAnswer = async (req, query, chatHistory, summariesEnabled = false) => {
   const embeddings = new OpenAIEmbeddings({
     azureOpenAIApiInstanceName: config.azureOpenAI.openAiInstanceName,
     azureOpenAIApiKey: config.azureOpenAI.openAiKey,
@@ -149,13 +149,14 @@ const fetchAnswer = async (req, query, chatHistory) => {
       onFailedAttempt
     })
 
-  const { response: summariesResponse, hallucinated } = await runFetchAnswerQuery({ query, chatHistory, summariesMode: true, model, embeddings })
-  const isResponseValid = validateResponseSummaries(summariesResponse)
+  if (summariesEnabled) {
+    const { response: summariesResponse, hallucinated } = await runFetchAnswerQuery({ query, chatHistory, summariesMode: true, model, embeddings })
+    const isResponseValid = validateResponseSummaries(summariesResponse)
 
-  if (isResponseValid && !hallucinated && hallucinated !== undefined) {
-    return summariesResponse?.answer
+    if (isResponseValid && !hallucinated && hallucinated !== undefined) {
+      return summariesResponse?.answer
+    }
   }
-
   const { response } = await runFetchAnswerQuery({ query, chatHistory, summariesMode: false, embeddings, model })
 
   return response?.answer

--- a/app/services/query-service.js
+++ b/app/services/query-service.js
@@ -32,6 +32,22 @@ const validateResponseLinks = (response, query) => {
       return trackIssueAndBreak('validateResponseLinks failed because response object does not contain answer or context fields')
     }
 
+    // while it still does not return JSON always, have this check to avoid invalidating reasonable string responses
+    if (typeof response.answer === 'string'
+      && !response.answer.includes('Unknown')
+      && !response.answer.includes('tool cannot answer that kind of question')
+      && response.answer.length > 100
+      && !response.answer.includes('not mentioned in the provided documents')
+      && !response.answer.includes('not included in the provided documents')
+      && !response.answer.includes('not found in the provided documents')
+      && !response.answer.includes('documents do not mention')
+      && !response.answer.includes('documents do not include')
+      && !response.answer.includes('not found in the documents')
+      && !response.answer.includes('not mentioned in the documents')
+    ) {
+      return true
+    }
+
     const responseEntriesAndLinks = extractLinksForValidatingResponse(JSON.parse(response.answer))
     const trueEntriesAndLinks = extractLinksForValidatingResponse(response.context)
 

--- a/app/services/query-service.js
+++ b/app/services/query-service.js
@@ -35,7 +35,11 @@ const validateResponseLinks = (response, query) => {
     const responseEntriesAndLinks = extractLinksForValidatingResponse(JSON.parse(response.answer))
     const trueEntriesAndLinks = extractLinksForValidatingResponse(response.context)
 
-    if (responseEntriesAndLinks.length !== 0 && trueEntriesAndLinks.length === 0) {
+    if (trueEntriesAndLinks === undefined || trueEntriesAndLinks.length === 0) {
+      return trackIssueAndBreak('validateResponseLinks failed because no links detected in true context object')
+    }
+
+    if (!responseEntriesAndLinks && !trueEntriesAndLinks || (responseEntriesAndLinks !== undefined && responseEntriesAndLinks.length !== 0 && trueEntriesAndLinks !== undefined && trueEntriesAndLinks.length === 0)) {
       return trackIssueAndBreak('validateResponseLinks failed because hallucinated links detected in response objects')
     }
 
@@ -43,7 +47,7 @@ const validateResponseLinks = (response, query) => {
       entry.matches.some((link) => !trueEntriesAndLinks.some((trueEntry) => trueEntry.matches.includes(link)))
     )
 
-    if (invalidLinks.length > 0) {
+    if (invalidLinks !== undefined && invalidLinks.length > 0) {
       return trackIssueAndBreak('validateResponseLinks failed because invalid links detected in response objects')
     }
   } catch {
@@ -108,13 +112,17 @@ const runFetchAnswerQuery = async ({ query, chatHistory, summariesMode, embeddin
       input: redactedQuery
     })
 
-    return response
+    const hallucinated = !validateResponseLinks(response, query)
+
+    return { response, hallucinated }
   } catch (error) {
     trackFetchResponseFailed({
       errorMessage: error.message,
       requestQuery: query
     })
-    return { answer: 'This tool cannot answer that kind of question, ask something about Defra funding instead' }
+    return {
+      response: { answer: 'This tool cannot answer that kind of question, ask something about Defra funding instead' }
+    }
   }
 }
 
@@ -137,18 +145,14 @@ const fetchAnswer = async (req, query, chatHistory) => {
       onFailedAttempt
     })
 
-  const summariesResponse = await runFetchAnswerQuery({ query, chatHistory, summariesMode: true, model, embeddings })
+  const { response: summariesResponse, hallucinated } = await runFetchAnswerQuery({ query, chatHistory, summariesMode: true, model, embeddings })
   const isResponseValid = validateResponseSummaries(summariesResponse)
 
-  if (isResponseValid) {
-    validateResponseLinks(summariesResponse, query)
-
+  if (isResponseValid && !hallucinated && hallucinated !== undefined) {
     return summariesResponse?.answer
   }
 
-  const response = await runFetchAnswerQuery({ query, chatHistory, summariesMode: false, embeddings, model })
-
-  validateResponseLinks(response, query)
+  const { response } = await runFetchAnswerQuery({ query, chatHistory, summariesMode: false, embeddings, model })
 
   return response?.answer
 }

--- a/app/utils/langchain-utils.js
+++ b/app/utils/langchain-utils.js
@@ -70,21 +70,22 @@ const extractLinksForValidatingResponse = (jsonObj) => {
 
 const validateResponseSummaries = (response) => {
   try {
-    const answer = JSON.parse(response.answer)
-    const items = answer.items
-
-    if (answer === 'Unknown') {
+    if (response.answer === 'Unknown') {
       return false
     }
 
-    if (!items || items.length === 0) {
-      return false
-    }
+    try {
+      const items = JSON.parse(response.answer).items
 
-    const invalidSummary = items.some(item => !item.title || !item.scheme || !item.url || !item.summary)
+      const invalidSummary = items && items.length > 0 && items.some(item => !item.title || !item.scheme || !item.url || !item.summary)
 
-    if (invalidSummary) {
-      return false
+      if (invalidSummary) {
+        return false
+      }
+    } catch {
+      if (typeof response.answer === 'string') {
+        return true
+      }
     }
 
     return true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-find-ai-frontend",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "",
   "homepage": "github.com?owner=defra&repo=fcp-find-ai-frontend&organization=defra",
   "main": "app/index.js",


### PR DESCRIPTION
I effectively didn't track the hallucinated links in the summaries response and thus didn't validate response from the summaries search effectively