### PR TITLE
Summaries Validation and Hallucination Test fix

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -73,7 +73,7 @@ const schema = Joi.object({
 const config = {
   env: process.env.NODE_ENV,
   appInsightsKey: process.env.APPINSIGHTS_CONNECTIONSTRING,
-  version: '0.1.45',
+  version: '0.1.46',
   logLevel: process.env.LOG_LEVEL || 'error',
 
   auth: {

--- a/app/domain/prompt.js
+++ b/app/domain/prompt.js
@@ -7,8 +7,8 @@ const getPrompt = (summariesMode) => {
   You are a Gov UK DEFRA AI Assistant, whose job it is to retrieve and summarise information regarding available grants for farmers and land agents. 
   Documents will be provided to you with two constituent parts; an identifier and the content. The identifier will be at the start of the document, within a set of parentheses in the following format:
     (Title: Document Title | Grant Scheme Name: Grant Scheme the grant option belongs to | Source: Document Source URL | Chunk Number: The chunk number for a given parent document)
-    The start of the content will follow the "===" string in the document.
-    ${summariesMode && 'The documents provided may not include the relevant information to answer the query sufficiently. If the document do not mention or include the information,always respond only with "Unknown" as the answer.'}
+  The start of the content will follow the "===" string in the document.
+  ${summariesMode && 'The documents provided may not include the relevant information to answer the query sufficiently. If the document do not mention or include the information,always respond only with "Unknown" as the answer.'}
     
   - Respond in British English, not American English.
   - Use a neutral tone without being too polite. 

--- a/app/domain/prompt.js
+++ b/app/domain/prompt.js
@@ -7,8 +7,8 @@ const getPrompt = (summariesMode) => {
   You are a Gov UK DEFRA AI Assistant, whose job it is to retrieve and summarise information regarding available grants for farmers and land agents. 
   Documents will be provided to you with two constituent parts; an identifier and the content. The identifier will be at the start of the document, within a set of parentheses in the following format:
     (Title: Document Title | Grant Scheme Name: Grant Scheme the grant option belongs to | Source: Document Source URL | Chunk Number: The chunk number for a given parent document)
-  The start of the content will follow the "===" string in the document.
-  ${summariesMode && 'The documents provided may not include the relevant information to answer the query sufficiently. If the document do not mention or include the information,always respond only with "Unknown" as the answer.'}
+    The start of the content will follow the "===" string in the document.
+    ${summariesMode && 'The documents provided may not include the relevant information to answer the query sufficiently. If the document do not mention or include the information,always respond only with "Unknown" as the answer.'}
     
   - Respond in British English, not American English.
   - Use a neutral tone without being too polite. 

--- a/app/routes/conversation.js
+++ b/app/routes/conversation.js
@@ -77,7 +77,7 @@ module.exports = [
         answer: redactedQuery
       })
 
-      const response = await fetchAnswer(request, redactedQuery, chatHistory, config.azureOpenAI.cacheEnabled)
+      const { response } = await fetchAnswer(request, redactedQuery, chatHistory, config.azureOpenAI.cacheEnabled)
 
       const endTime = new Date()
 

--- a/app/routes/testing.js
+++ b/app/routes/testing.js
@@ -32,7 +32,8 @@ module.exports = [
           try {
             const cacheEnabled = false
             const summariesEnabled = false
-            response = await fetchAnswer(request, input, [], cacheEnabled, summariesEnabled)
+            const { answer } = await fetchAnswer(request, input, [], cacheEnabled, summariesEnabled)
+            response = answer
             parseResponse = parseMessage(request, response)
             passedValidation = parseResponse !== undefined
           } catch (error) {

--- a/app/routes/testing.js
+++ b/app/routes/testing.js
@@ -32,8 +32,8 @@ module.exports = [
           try {
             const cacheEnabled = false
             const summariesEnabled = false
-            const { answer } = await fetchAnswer(request, input, [], cacheEnabled, summariesEnabled)
-            response = answer
+            const answer = await fetchAnswer(request, input, [], cacheEnabled, summariesEnabled)
+            response = answer.response
             parseResponse = parseMessage(request, response)
             passedValidation = parseResponse !== undefined
           } catch (error) {

--- a/app/services/query-service.js
+++ b/app/services/query-service.js
@@ -164,7 +164,7 @@ const fetchAnswer = async (req, query, chatHistory, cacheEnabled, summariesEnabl
   if (summariesEnabled) {
     const { response: summariesResponse, hallucinated } = await runFetchAnswerQuery({ query, chatHistory, summariesMode: true, model, embeddings })
 
-    if (isResponseValid && !hallucinated) {
+    if (!hallucinated) {
       // TODO cache summaries response after enabled
       return {
         answer: summariesResponse?.answer,

--- a/app/services/query-service.js
+++ b/app/services/query-service.js
@@ -166,7 +166,11 @@ const fetchAnswer = async (req, query, chatHistory, cacheEnabled, summariesEnabl
 
     if (!hallucinated && hallucinated !== undefined) {
       // TODO cache summaries response after enabled
-      return summariesResponse?.answer
+      return {
+        answer: summariesResponse?.answer,
+        summariesMode: true,
+        hallucinated
+      }
     }
   }
 
@@ -176,7 +180,11 @@ const fetchAnswer = async (req, query, chatHistory, cacheEnabled, summariesEnabl
     await uploadToCache(query, response.answer)
   }
 
-  return response?.answer
+  return {
+    response: response?.answer,
+    summariesMode: false,
+    hallucinated
+  }
 }
 
 module.exports = {

--- a/app/utils/langchain-utils.js
+++ b/app/utils/langchain-utils.js
@@ -55,10 +55,13 @@ const extractLinksForValidatingResponse = (jsonObj) => {
     return []
   }
 
-  const urlRegex = /https?:\/\/[^\s|)]+/g
+  // Improved URL regex to match valid URLs and exclude unwanted strings
+  const urlRegex = /\bhttps?:\/\/[^\s"')]+/g
 
   const entriesAndLinks = entries.map((entryObj) => {
-    const matches = entryObj.link.match(urlRegex).filter((value, index, self) => self.indexOf(value) === index)
+    const matches = entryObj.link.match(urlRegex)
+      .map((url) => url.replace('/api/content', '').replace(/["',]/g, ''))
+      .filter((value, index, self) => self.indexOf(value) === index)
     return {
       matches,
       entry: entryObj.entry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fcp-find-ai-frontend",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fcp-find-ai-frontend",
-      "version": "0.1.45",
+      "version": "0.1.46",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/logger": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-find-ai-frontend",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "",
   "homepage": "github.com?owner=defra&repo=fcp-find-ai-frontend&organization=defra",
   "main": "app/index.js",

--- a/test/unit/routes/conversation.test.js
+++ b/test/unit/routes/conversation.test.js
@@ -93,11 +93,13 @@ describe('/conversation', () => {
     })
 
     test('send user input and load response', async () => {
-      fetchAnswer.mockResolvedValue(JSON.stringify({
-        answer: 'responseMsg',
-        items: [],
-        source_urls: []
-      }))
+      fetchAnswer.mockResolvedValue({
+        response: JSON.stringify({
+          answer: 'responseMsg',
+          items: [],
+          source_urls: []
+        })
+      })
       const mockRequest = {
         payload: {
           input: 'grants for deer fencing'

--- a/test/unit/services/query-service.test.js
+++ b/test/unit/services/query-service.test.js
@@ -23,7 +23,7 @@ describe('query-service', () => {
       const input = 'deer fencing'
       ChatPromptTemplate.fromMessages.mockReturnValue(prompt)
 
-      const response = await fetchAnswer({}, input)
+      const { response } = await fetchAnswer({}, input)
 
       expect(JSON.parse(response).answer).toStrictEqual(JSON.stringify({
         answer: 'generated response',
@@ -121,6 +121,220 @@ describe('query-service', () => {
       expect(validatedResponseInvalid).toStrictEqual(false)
       expect(validatedResponseNoContext).toStrictEqual(false)
       expect(validatedResponseNoAnswer).toStrictEqual(false)
+    })
+
+    test('fetchAnswer returns summary answer when summariesEnabled is true', async () => {
+      createRetrievalChain.mockResolvedValue({
+        invoke: jest.fn().mockResolvedValue({
+          answer: JSON.stringify({ answer: 'summary response', items: [] })
+        })
+      })
+
+      const prompt = jest.fn()
+      const input = 'deer fencing'
+      ChatPromptTemplate.fromMessages.mockReturnValue(prompt)
+
+      const { response, summariesMode, hallucinated } = await fetchAnswer({}, input, [], false, true)
+
+      expect(JSON.parse(response).answer).toStrictEqual('summary response')
+      expect(createStuffDocumentsChain).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt })
+      )
+
+      if (!hallucinated) {
+        expect(summariesMode).toBe(true)
+      }
+    })
+
+    test('fetchAnswer does not return summary answer when summariesEnabled is false', async () => {
+      createRetrievalChain.mockResolvedValue({
+        invoke: jest.fn().mockResolvedValue({
+          answer: JSON.stringify({ answer: 'full index response', items: [] })
+        })
+      })
+
+      const prompt = jest.fn()
+      const input = 'deer fencing'
+      ChatPromptTemplate.fromMessages.mockReturnValue(prompt)
+
+      const { response, summariesMode } = await fetchAnswer({}, input, [], false, false)
+
+      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(createStuffDocumentsChain).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt })
+      )
+      expect(summariesMode).toBe(false)
+    })
+
+    test('fetchAnswer falls back to full index when summary answer returns "Unknown"', async () => {
+      createRetrievalChain
+        .mockResolvedValueOnce({
+          invoke: jest.fn().mockResolvedValue({
+            answer: JSON.stringify({ answer: 'Unknown', items: [] })
+          })
+        })
+        .mockResolvedValueOnce({
+          invoke: jest.fn().mockResolvedValue({
+            answer: JSON.stringify({ answer: 'full index response', items: [] })
+          })
+        })
+
+      const prompt = jest.fn()
+      const input = 'deer fencing'
+      ChatPromptTemplate.fromMessages.mockReturnValue(prompt)
+
+      const { response } = await fetchAnswer({}, input, [], false, true)
+
+      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(createStuffDocumentsChain).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt })
+      )
+    })
+
+    test('fetchAnswer does not fall back to full index when summary answer is valid', async () => {
+      createRetrievalChain.mockResolvedValueOnce({
+        invoke: jest.fn().mockResolvedValue({
+          answer: JSON.stringify({ answer: 'summary response', items: [] })
+        })
+      })
+
+      const prompt = jest.fn()
+      const input = 'deer fencing'
+      ChatPromptTemplate.fromMessages.mockReturnValue(prompt)
+
+      const { response } = await fetchAnswer({}, input, [], false, true)
+
+      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(createStuffDocumentsChain).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt })
+      )
+    })
+
+    test('fetchAnswer detects hallucinated link in summary answer and falls back to full index', async () => {
+      createRetrievalChain
+        .mockResolvedValueOnce({
+          invoke: jest.fn().mockResolvedValue({
+            answer: JSON.stringify({
+              answer: 'summary response with hallucinated link',
+              items: [
+                {
+                  title: 'Fake title',
+                  scheme: 'Fake scheme',
+                  url: 'https://www.fake-link.com',
+                  summary: 'Fake summary'
+                }
+              ],
+              source_urls: ['https://www.fake-link.com']
+            })
+          })
+        })
+        .mockResolvedValueOnce({
+          invoke: jest.fn().mockResolvedValue({
+            answer: JSON.stringify({ answer: 'full index response', items: [] })
+          })
+        })
+
+      const prompt = jest.fn()
+      const input = 'deer fencing'
+      ChatPromptTemplate.fromMessages.mockReturnValue(prompt)
+
+      const { response } = await fetchAnswer({}, input, [], false, true)
+
+      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(createStuffDocumentsChain).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt })
+      )
+    })
+
+    test('fetchAnswer does not fall back to full index when summary answer has no hallucinated links', async () => {
+      createRetrievalChain.mockResolvedValueOnce({
+        invoke: jest.fn().mockResolvedValue({
+          answer: JSON.stringify({
+            answer: 'summary response',
+            items: [
+              {
+                title: 'True title',
+                scheme: 'True scheme',
+                url: 'https://www.true-link.com',
+                summary: 'True summary'
+              }
+            ],
+            source_urls: ['https://www.true-link.com']
+          })
+        })
+      })
+
+      const prompt = jest.fn()
+      const input = 'deer fencing'
+      ChatPromptTemplate.fromMessages.mockReturnValue(prompt)
+
+      const { response } = await fetchAnswer({}, input, [], false, true)
+
+      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(createStuffDocumentsChain).toHaveBeenCalledWith(
+        expect.objectContaining({ prompt })
+      )
+    })
+  })
+
+  describe('validateResponseLinks', () => {
+    test('validateResponseLinks detects hallucinated links in summary answer', async () => {
+      const mockResponseWithHallucinatedLinks = {
+        answer: JSON.stringify({
+          answer: 'summary response with hallucinated link',
+          items: [
+            {
+              title: 'Fake title',
+              scheme: 'Fake scheme',
+              url: 'https://www.fake-link.com',
+              summary: 'Fake summary'
+            }
+          ],
+          source_urls: ['https://www.fake-link.com']
+        }),
+        context: [
+          {
+            pageContent:
+              '(Title: True title | Grant Scheme Name: True scheme | Source: https://www.true-link.com | Chunk Number: 0)===True summary',
+            metadata: {}
+          }
+        ]
+      }
+
+      const isValid = validateResponseLinks(
+        mockResponseWithHallucinatedLinks,
+        'deer fencing'
+      )
+
+      expect(isValid).toStrictEqual(false)
+    })
+
+    test('validateResponseLinks passes when no hallucinated links are present', async () => {
+      const mockResponseValid = {
+        answer: JSON.stringify({
+          answer: 'summary response',
+          items: [
+            {
+              title: 'True title',
+              scheme: 'True scheme',
+              url: 'https://www.true-link.com',
+              summary: 'True summary'
+            }
+          ],
+          source_urls: ['https://www.true-link.com']
+        }),
+        context: [
+          {
+            pageContent:
+              '(Title: True title | Grant Scheme Name: True scheme | Source: https://www.true-link.com | Chunk Number: 0)===True summary',
+            metadata: {}
+          }
+        ]
+      }
+
+      const isValid = validateResponseLinks(mockResponseValid, 'deer fencing')
+
+      expect(isValid).toStrictEqual(true)
     })
   })
 })

--- a/test/unit/services/query-service.test.js
+++ b/test/unit/services/query-service.test.js
@@ -136,7 +136,7 @@ describe('query-service', () => {
 
       const { response, summariesMode, hallucinated } = await fetchAnswer({}, input, [], false, true)
 
-      expect(JSON.parse(response).answer).toStrictEqual('summary response')
+      expect(JSON.parse(response).answer).toStrictEqual(JSON.stringify({ answer: 'summary response', items: [] }))
       expect(createStuffDocumentsChain).toHaveBeenCalledWith(
         expect.objectContaining({ prompt })
       )
@@ -159,7 +159,7 @@ describe('query-service', () => {
 
       const { response, summariesMode } = await fetchAnswer({}, input, [], false, false)
 
-      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(JSON.parse(response).answer).toStrictEqual(JSON.stringify({ answer: 'full index response', items: [] }))
       expect(createStuffDocumentsChain).toHaveBeenCalledWith(
         expect.objectContaining({ prompt })
       )
@@ -185,7 +185,7 @@ describe('query-service', () => {
 
       const { response } = await fetchAnswer({}, input, [], false, true)
 
-      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(JSON.parse(response).answer).toStrictEqual(JSON.stringify({ answer: 'full index response', items: [] }))
       expect(createStuffDocumentsChain).toHaveBeenCalledWith(
         expect.objectContaining({ prompt })
       )
@@ -204,7 +204,7 @@ describe('query-service', () => {
 
       const { response } = await fetchAnswer({}, input, [], false, true)
 
-      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(JSON.parse(response).answer).toStrictEqual(JSON.stringify({ answer: 'full index response', items: [] }))
       expect(createStuffDocumentsChain).toHaveBeenCalledWith(
         expect.objectContaining({ prompt })
       )
@@ -240,7 +240,7 @@ describe('query-service', () => {
 
       const { response } = await fetchAnswer({}, input, [], false, true)
 
-      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(JSON.parse(response).answer).toStrictEqual(JSON.stringify({ answer: 'full index response', items: [] }))
       expect(createStuffDocumentsChain).toHaveBeenCalledWith(
         expect.objectContaining({ prompt })
       )
@@ -270,7 +270,7 @@ describe('query-service', () => {
 
       const { response } = await fetchAnswer({}, input, [], false, true)
 
-      expect(JSON.parse(response).answer).toStrictEqual('full index response')
+      expect(JSON.parse(response).answer).toStrictEqual(JSON.stringify({ answer: 'full index response', items: [] }))
       expect(createStuffDocumentsChain).toHaveBeenCalledWith(
         expect.objectContaining({ prompt })
       )


### PR DESCRIPTION
I noticed that it was saying the response is hallucinated even when it was not. The fix extends to actually finding the summaries, correctly testing if they are not hallucinated, and then passing the titles to the search so it can foxus on these grants